### PR TITLE
updating form to use UUID for keys instead of indices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-router-dom": "^6.15.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.9.5",
+        "uuid": "^9.0.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -16253,6 +16254,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -17331,9 +17340,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-router-dom": "^6.15.0",
     "react-scripts": "^5.0.1",
     "typescript": "^4.9.5",
+    "uuid": "^9.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
     <title>Cook With Me!</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>Cooking together, learning together</noscript>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/apis/AdminAPI/RecipeAPI.js
+++ b/src/apis/AdminAPI/RecipeAPI.js
@@ -77,6 +77,7 @@ export async function getFormPresets() {
         method: 'GET',
         headers: headers
     });
+    
     let presets = response.json();
     return await presets;
 }

--- a/src/components/Admin/RecipeForm/Ingredients/IngredientComponent.tsx
+++ b/src/components/Admin/RecipeForm/Ingredients/IngredientComponent.tsx
@@ -6,7 +6,6 @@ import { Add, Delete } from "@mui/icons-material";
 interface IngredientComponentProps {
     updateComponent: Function,
     removeComponent: Function,
-    key: number,
     index: number,
     metricPresets: Array<string>,
     ingredientPresets: Array<string>,
@@ -23,9 +22,9 @@ interface IngredientProps {
     name: string,
 }
 
-const IngredientComponent = ({updateComponent, removeComponent, ingredientComponent, metricPresets, ingredientPresets, key, index}: IngredientComponentProps) => {
+const IngredientComponent = ({updateComponent, removeComponent, ingredientComponent, metricPresets, ingredientPresets, index}: IngredientComponentProps) => {
     const[componentName, setComponentName] = useState(ingredientComponent.component_name || "");
-    const[ingredients, setIngredients] = useState(ingredientComponent.ingredients || new Array(5).fill({amount: "", metric: "", name: ""}));
+    const[ingredients, setIngredients] = useState(ingredientComponent.ingredients);
 
     useEffect(() => {
         updateComponent({
@@ -39,12 +38,12 @@ const IngredientComponent = ({updateComponent, removeComponent, ingredientCompon
     }
 
     const addNewIngredient = () => {
-        setIngredients([...ingredients, {id: null, amount: "", metric: "", name: ""}]);
+        setIngredients([...ingredients, {id: Math.floor(Math.random()*10), amount: "", metric: "", name: ""}]);
     }
 
     const removeIngredient = (index: number) => {
-        const updatedComponents = ingredients.filter((_, idx) => idx !== index);
-        setIngredients(updatedComponents);
+        const updatedIngredients = ingredients.filter((_, idx) => idx !== index);
+        setIngredients(updatedIngredients);
     }
 
     const updateIngredientList = (updatedIngredient: IngredientProps, index: number) => {
@@ -75,8 +74,8 @@ const IngredientComponent = ({updateComponent, removeComponent, ingredientCompon
                 {
                     ingredients.map((ingredient, index) => (
                         <IngredientItem 
-                            key={ingredient.id || index}
                             index={index}
+                            key={ingredient.id}
                             ingredientPresets={ingredientPresets}
                             metricPresets={metricPresets}
                             ingredient={ingredient}

--- a/src/components/Admin/RecipeForm/Ingredients/IngredientForm.tsx
+++ b/src/components/Admin/RecipeForm/Ingredients/IngredientForm.tsx
@@ -3,29 +3,33 @@ import {updateRecipeIngredientComponent} from  '../../../../store/actions/recipe
 import IngredientComponent from "./IngredientComponent";
 import { Button } from "@mui/material";
 import { useDispatch } from "react-redux";
+import {newId, createNewItems} from '../../../../helpers/generateNewItems.js';
 
 interface IngredientComponentProps {
-    componentName: string
+    id: string,
+    componentName: string,
     ingredients: Array<Object>
 }
 
 interface RecipeFormProps {
     metricPresets: Array<string>,
     ingredientPresets:  Array<string>,
-
     ingredientElements: Array<IngredientComponentProps>
 }
 
+
+
 const IngredientForm = ({metricPresets, ingredientPresets, ingredientElements}: RecipeFormProps) => {
     const dispatch = useDispatch();
-    const [ingredientComponents, setIngredientComponents] = useState(ingredientElements || [{}]);
+    const [ingredientComponents, setIngredientComponents] = useState(ingredientElements || [ {id: newId(),  componentName: "", ingredients: createNewItems(5, {id: "", amount: "", metric: "", name: ""}) }]);
+
    
     useEffect(() => {
         dispatch(updateRecipeIngredientComponent(ingredientComponents));
     }, [ingredientComponents]);
 
     const addNewComponent = () => {
-        setIngredientComponents([...ingredientComponents, { componentName: "", ingredients: new Array(5).fill({id: null, amount: "", metric: "", name: ""}) }]);
+        setIngredientComponents([...ingredientComponents, { id: newId(), componentName: "", ingredients: createNewItems(5, {id: "", amount: "", metric: "", name: ""}) }]);
     }
 
     const removeComponent = (index: Number) => {
@@ -44,6 +48,7 @@ const IngredientForm = ({metricPresets, ingredientPresets, ingredientElements}: 
             }
             return component;
         })
+        
         setIngredientComponents(updatedIngredients);
     }
 

--- a/src/components/Admin/RecipeForm/Ingredients/IngredientItem.tsx
+++ b/src/components/Admin/RecipeForm/Ingredients/IngredientItem.tsx
@@ -6,10 +6,10 @@ interface IngredientItemProps {
     removeIngredient: Function,
     updateIngredientList: Function,
     index: Number,
-    key: Number,
     metricPresets: Array<string>,
     ingredientPresets: Array<string>,
     ingredient: {
+        id: number | null,
         amount: string,
         metric: string,
         name: string
@@ -17,7 +17,7 @@ interface IngredientItemProps {
 }
 
 const IngredientItem = ( {updateIngredientList, removeIngredient, ingredient, metricPresets, ingredientPresets, index}: IngredientItemProps) => {
-    const [id, setId] = useState<string | null>(ingredient.id || "");
+    const [id, setId] = useState<number | null>(ingredient.id || null );
     const [amount, setAmount] = useState<string | null>(ingredient.amount || "");
     const [metric, setMetric] = useState<string | null>(ingredient.metric || "");
     const [name, setName] = useState<string | null> (ingredient.name || "");
@@ -71,7 +71,7 @@ const IngredientItem = ( {updateIngredientList, removeIngredient, ingredient, me
                     renderInput={(params) => <TextField {...params} id="ingredient" fullWidth label="Ingredient" variant="outlined" />
                 }
                 />
-                <Button color="error" variant="contained" onClick={() => {deleteItem()}}><Remove/></Button>
+                <Button color="error" variant="contained" onClick={deleteItem}><Remove/></Button>
             </Paper>
         </Box>
     )

--- a/src/components/Admin/RecipeForm/Instructions/InstructionForm.tsx
+++ b/src/components/Admin/RecipeForm/Instructions/InstructionForm.tsx
@@ -4,8 +4,10 @@ import RecipeComponent from "../../../Basics/RecipeComponent/RecipeComponent";
 import {updateRecipeInstructionalComponent} from  '../../../../store/actions/recipeActions.js';
 import { Button } from "@mui/material";
 import { useDispatch } from "react-redux";
+import {newId, createNewItems} from '../../../../helpers/generateNewItems.js';
 
 interface InstructionalComponentProps {
+    id: string,
     componentName: string
     instructions: Array<Object>
 }
@@ -14,17 +16,16 @@ interface RecipeFormProps {
     instructionalElements: Array<InstructionalComponentProps>
 }
 
-
 const InstructionForm = ({instructionalElements}: RecipeFormProps) => {
     const dispatch = useDispatch();
-    const [instructionalComponent, setInstructionalComponent] = useState(instructionalElements || [{}])
+    const [instructionalComponent, setInstructionalComponent] = useState(instructionalElements || [ {id: newId(),  componentName: "", instructions: createNewItems(6, { id: "", description: "", image: ""}) }]);
    
     useEffect(() => {
         dispatch(updateRecipeInstructionalComponent(instructionalComponent));
     }, [instructionalComponent]);
 
     const addNewComponent = () => {
-        setInstructionalComponent([...instructionalComponent, { componentName: "", instructions: new Array(3).fill({description: "", image: ""})}]);
+        setInstructionalComponent([...instructionalComponent, { id: newId(), componentName: "", instructions: createNewItems(6, { id: "", description: "", image: ""}) }]);
     }
 
     const removeComponent = (index: Number) => {

--- a/src/components/Admin/RecipeForm/Instructions/InstructionItem.tsx
+++ b/src/components/Admin/RecipeForm/Instructions/InstructionItem.tsx
@@ -4,8 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import './Instruction.css';
 
 interface InstructionItemProps {
-    key: Number,
-    index: Number,
+    index: number,
     instruction: {
         description: string,
         image: string
@@ -14,7 +13,7 @@ interface InstructionItemProps {
     updateInstructions: Function
 }
 
-const InstructionItem = ({removeInstruction, updateInstructions, instruction, key, index} : InstructionItemProps) => {
+const InstructionItem = ({removeInstruction, updateInstructions, instruction, index} : InstructionItemProps) => {
     const [image, setImage] = useState(instruction.image || "");
     const [description, setDescription] = useState(instruction.description || "");
     

--- a/src/components/Admin/RecipeForm/Instructions/InstructionalComponent.tsx
+++ b/src/components/Admin/RecipeForm/Instructions/InstructionalComponent.tsx
@@ -20,9 +20,9 @@ interface InstructionProps {
     image: string,
 }
 
-const InstructionalComponent = ({updateComponent, removeComponent, instructionalComponent, index}:InstructionalComponentProps) => {
+const InstructionalComponent = ({updateComponent, removeComponent, instructionalComponent, index} :InstructionalComponentProps) => {
     const [componentName, setComponentName] = useState(instructionalComponent.component_name || "")
-    const [instructions, setInstructions] = useState(instructionalComponent.instructions || new Array(6).fill({description: "", image: ""}));
+    const [instructions, setInstructions] = useState(instructionalComponent.instructions);
 
     useEffect(() => {
         updateComponent({
@@ -71,7 +71,7 @@ const InstructionalComponent = ({updateComponent, removeComponent, instructional
                 {
                     instructions.map((instruction, index) => (
                         <InstructionItem
-                            key={instruction.id || index}
+                            key={instruction.id}
                             index={index}
                             instruction={instruction}
                             removeInstruction={removeInstruction}

--- a/src/components/Admin/RecipeForm/Notes/NoteForm.tsx
+++ b/src/components/Admin/RecipeForm/Notes/NoteForm.tsx
@@ -4,8 +4,12 @@ import {updateRecipeNotes} from  '../../../../store/actions/recipeActions.js';
 import { useDispatch } from "react-redux";
 import { Button } from "@mui/material";
 import { Add } from "@mui/icons-material";
+import {newId, createNewItems} from '../../../../helpers/generateNewItems.js';
+
 
 interface NoteItemProps {
+    id: number,
+    index: number,
     stepId: number,
     description: string
 }
@@ -17,14 +21,14 @@ interface RecipeNotesProps {
 const NoteForm = ({recipeNotes}: RecipeNotesProps) => {
     const dispatch = useDispatch();
 
-    const [notes, setNotes] = useState(recipeNotes || [{description: "", stepId: 1}, {description: "", stepId: 2}, {description: "", stepId: 3}, {description: "", stepId: 4}, {description: "", stepId: 5}])
+    const [notes, setNotes] = useState(recipeNotes || createNewItems(5, { id: "", description: "" }));
 
     useEffect(() => {
         dispatch(updateRecipeNotes(notes));
     }, [recipeNotes, notes])
 
     const addNewNote = () => {
-        setNotes([...notes, {description: "", stepId: notes.length }]);
+        setNotes([...notes, {id: newId(), description: "", stepId: notes.length, index: notes.length-1}]);
     }
 
     const removeNote = (index: Number) => {
@@ -55,7 +59,7 @@ const NoteForm = ({recipeNotes}: RecipeNotesProps) => {
                     <NoteItem
                         removeNote={removeNote}
                         index={index}
-                        key={index} 
+                        key={note.id} 
                         note={note}   
                         updateNotes={updateNotes}
                     />

--- a/src/helpers/generateNewItems.js
+++ b/src/helpers/generateNewItems.js
@@ -1,0 +1,18 @@
+import {v4 as uuidv4} from 'uuid';
+
+export function newId() {
+    return uuidv4()
+}
+
+export function createNewItems(length, object) {
+    var newItems = new Array(length).fill(object);
+    var populateData = newItems.map((item, index) => {
+        return {
+            ...item,
+            id: newId()
+        }
+    })
+
+    return populateData;
+}
+


### PR DESCRIPTION
# Overview

Updating issue with admin form.

*Bug:*
deleting an item causes only the latest item to be deleted

*Solution:*
The solution was to give unique id's to each child in the map react items. 

The issue was that the keys were using indices, so when an index (key) exists, it doesn't rerender