### PR TITLE
Joshc/adding option to update presets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,10 +43,10 @@
 
 .App-main-body {
   background-color: white;
-  min-height: 100vh;
+  height: 100%;
   margin: auto;
   /* width: 60%; */
-  max-width: 1200px;
+  /* max-width: 1250px; */
 }
 
 @keyframes App-logo-spin {
@@ -61,6 +61,7 @@
 .App-recipeBoxes {
   /* display: flex;
   flex-direction: row; */
+  height: inherit;
   flex-wrap: wrap;
   justify-content: center;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import Recipe from './components/Recipe/Recipe.tsx';
 import RecipeForm from './components/Admin/RecipeForm/RecipeForm.tsx';
 import { getRecipes } from './apis/AdminAPI/RecipeAPI';
 import Header from './components/Basics/Header/Header.tsx';
-import RecipesPage from './components/Admin/RecipesPage/RecipesPage.tsx';
+import AdminPage from './components/Admin/AdminPage.tsx';
 import PageNotFound from './components/Pages/NotFound/PageNotFound.tsx';
 function App() {
   const [recipes, setRecipes] = useState([]);
@@ -37,7 +37,7 @@ function App() {
         <div className="App-recipeBoxes">
           {/* <HashRouter> */}
             <Routes>
-              <Route exact path={`${path}admin`} element={<RecipesPage/>}/>
+              <Route exact path={`${path}admin`} element={<AdminPage/>}/>
               <Route exact path={`${path}admin/recipe-form/create`} element={<RecipeForm/> }/>
               <Route path={`${path}admin/recipe-form/edit/*`} element={<RecipeForm/>} />
               <Route exact path={`${path}`} element={<Recipes recipes={recipes}/> }/>

--- a/src/apis/AdminAPI/PresetAPI.js
+++ b/src/apis/AdminAPI/PresetAPI.js
@@ -1,0 +1,59 @@
+const endpoint = 'http://localhost:8000/api/v1/preset';
+// const endpoint = 'https://api.foodbaby.qvinyl.app/data-sync';
+
+const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+};
+
+export async function editPreset(presetType, id, value) {
+    const editPresetEndpoint = `${endpoint}/${presetType}/${id}`;
+
+    const options = {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+            name: value,
+        }),
+    };
+
+    try {
+        const response = await fetch(editPresetEndpoint, options);
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        return await response.json();
+    } catch (error) {
+        console.error('Error editing preset:', error);
+        // You might want to handle the error more gracefully, depending on your use case
+        throw error;
+    }
+}
+
+export async function deletePreset(presetType, id) {
+    const deletePresetEndpoint = `${endpoint}`;
+
+    const options = {
+        method: 'DELETE',
+        headers,
+        body: JSON.stringify ({
+            presetType: presetType, 
+            id: id
+        })
+    };
+
+    try {
+        const response = await fetch(deletePresetEndpoint, options);
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        return response.ok;
+    } catch (error) {
+        console.error('Error deleting preset:', error);
+        // You might want to handle the error more gracefully, depending on your use case
+        return error;
+    }
+}

--- a/src/apis/AdminAPI/PresetAPI.js
+++ b/src/apis/AdminAPI/PresetAPI.js
@@ -48,7 +48,7 @@ export async function deletePreset(presetType, id) {
         const response = await fetch(deletePresetEndpoint, options);
 
         if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
+            throw new Error(`HTTP error! Status: ${response.statusText}`);
         }
         return response.ok;
     } catch (error) {

--- a/src/apis/AdminAPI/RecipeAPI.js
+++ b/src/apis/AdminAPI/RecipeAPI.js
@@ -1,11 +1,10 @@
 const endpoint = 'http://localhost:8000/api/v1';
 // const endpoint = 'https://api.foodbaby.qvinyl.app/data-sync';
 
-const headers = 
-    {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-    };
+const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+};
 
 export async function createRecipe(formData: any) {
     let createRecipeEndpoint = `${endpoint}/postRecipe`;
@@ -80,5 +79,5 @@ export async function getFormPresets() {
 }
 
 export async function searchRecipesInAdmin() {
-    
+
 }

--- a/src/apis/AdminAPI/RecipeAPI.js
+++ b/src/apis/AdminAPI/RecipeAPI.js
@@ -1,6 +1,3 @@
-
-
-// const endpoint = 'http://13.57.96.24:8000'; 
 const endpoint = 'http://localhost:8000/api/v1';
 // const endpoint = 'https://api.foodbaby.qvinyl.app/data-sync';
 
@@ -80,4 +77,8 @@ export async function getFormPresets() {
     
     let presets = response.json();
     return await presets;
+}
+
+export async function searchRecipesInAdmin() {
+    
 }

--- a/src/components/Admin/AdminPage.tsx
+++ b/src/components/Admin/AdminPage.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import AdminDrawer from "./Navigation/AdminDrawer";
+import AdminContent from "./Content/AdminContent";
+import RecipesPage from "./RecipesPage/RecipesPage";
+import PresetManagementPage from "./PresetManagement/PresetManagementPage";
+
+const drawerItems = [
+    {   
+        title: 'Recipes',
+        component: <RecipesPage/>
+    },
+    {   
+        title: 'Presets',
+        component: <PresetManagementPage/>
+    },
+   
+]
+
+const AdminPage = () => {
+    const [tab, setTab] = useState(0);
+    const [component, setComponent] = useState(drawerItems[tab].component);
+    
+    const changeTab = (index: number) =>{
+        setTab(index);
+        setComponent(drawerItems[index].component);
+    }
+    
+    return (
+        <div style={{height: "100%", width: "100%", display: "flex", flexDirection: "row"}}>
+            <AdminDrawer 
+                drawerItems={drawerItems} 
+                tab={tab} 
+                changeTab={changeTab}
+            />
+            <AdminContent component={component}/>
+        </div>
+    )
+}
+
+export default AdminPage;

--- a/src/components/Admin/Content/AdminContent.css
+++ b/src/components/Admin/Content/AdminContent.css
@@ -1,0 +1,7 @@
+.AdminContent-container {
+    padding: 24px;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    border-left: 0.5px solid rgb(37, 37, 37, 0.5);
+}

--- a/src/components/Admin/Content/AdminContent.tsx
+++ b/src/components/Admin/Content/AdminContent.tsx
@@ -1,8 +1,9 @@
 import React from "react";
+import './AdminContent.css';
 
 const AdminContent = ({component}) => {
     return (
-        <div style={{padding: "24px", height: "100%", width: "100%", display: "flex", borderLeft: "0.5px solid rgb(37, 37, 37, 0.5)"}}>
+        <div className="AdminContent-container">
             {component}
         </div>
     )

--- a/src/components/Admin/Content/AdminContent.tsx
+++ b/src/components/Admin/Content/AdminContent.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const AdminContent = ({component}) => {
+    return (
+        <div style={{padding: "24px", height: "100%", width: "100%", display: "flex", borderLeft: "0.5px solid rgb(37, 37, 37, 0.5)"}}>
+            {component}
+        </div>
+    )
+}
+
+export default AdminContent;

--- a/src/components/Admin/Navigation/AdminDrawer.css
+++ b/src/components/Admin/Navigation/AdminDrawer.css
@@ -1,0 +1,20 @@
+.admin-drawer-container {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    width: 20%;
+    max-width: 250px;
+}
+
+.drawer {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    padding: 12px;
+    /* border-right: 0.5px solid rgb(37, 37, 37, 0.5) */
+}
+
+.button-container {
+   padding: 10px;
+}

--- a/src/components/Admin/Navigation/AdminDrawer.tsx
+++ b/src/components/Admin/Navigation/AdminDrawer.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import './AdminDrawer.css';
+import { Button } from "@mui/material";
+
+const AdminDrawer = ({tab, changeTab, drawerItems}: any) => {
+    
+    const updateCompenontTab = (index: number) => {
+        changeTab(index);
+    }
+
+    return (
+       <div className="admin-drawer-container">
+            <div className="drawer">
+                {   
+                    drawerItems.map((item, index) => (
+                        <div key={item.title}>
+                        {
+                            tab === index ? 
+                            <Button variant="contained" fullWidth className="button-container" onClick={() => updateCompenontTab(index)}>
+                                {item.title}
+                            </Button>
+                            :
+                            <Button fullWidth className="button-container" onClick={() => updateCompenontTab(index)}>
+                                {item.title}
+                            </Button>
+                        }
+                        </div>
+                    ))
+
+                }
+            </div>
+        </div>
+    )
+}
+
+export default AdminDrawer;

--- a/src/components/Admin/PresetManagement/Preset.css
+++ b/src/components/Admin/PresetManagement/Preset.css
@@ -1,0 +1,16 @@
+.preset-item {
+    display: flex;
+    flex-direction: row;
+    max-width: 500px;
+    
+}
+
+.preset-item :hover {
+    background: blue;
+}
+
+.preset-item-buttons {
+    display: flex;
+    flex-direction: row;
+    margin-left: auto;
+}

--- a/src/components/Admin/PresetManagement/PresetItem.tsx
+++ b/src/components/Admin/PresetManagement/PresetItem.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import './Preset.css';
+import { Button, TableCell, TableRow } from '@mui/material';
+import EditingPresetModal from '../../Basics/Modals/EditingPresetModal';
+import ConfirmationModal from '../../Basics/Modals/ConfirmationModal';
+
+const PresetItem = ({ preset, index }: any) => {
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+
+  const onEdit = () => {
+    console.log("Edit");
+    setIsEditModalOpen(true);
+  };
+
+  const cancelEdit = () => {
+    setIsEditModalOpen(false);
+  };
+
+  const onDelete = () => {
+    console.log("Delete");
+    setIsDeleteModalOpen(true);
+  };
+
+  const cancelDelete = () => {
+    setIsDeleteModalOpen(false);
+  };
+
+  return (
+    <TableRow>
+      <TableCell>{index}</TableCell>
+      <TableCell>{preset.name}</TableCell>
+      <TableCell>
+        <Button onClick={onEdit}> Edit </Button>
+        <Button color="error" onClick={onDelete}> Delete </Button>
+        {isEditModalOpen && 
+            <EditingPresetModal
+                isOpen={true} 
+                cancelEdit={cancelEdit} 
+                presetName={preset.name}
+            />}
+        {isDeleteModalOpen && 
+            <ConfirmationModal
+                isOpen={true} 
+                cancelDelete={cancelDelete} 
+                presetName={preset.name}
+            />}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default PresetItem;

--- a/src/components/Admin/PresetManagement/PresetItem.tsx
+++ b/src/components/Admin/PresetManagement/PresetItem.tsx
@@ -1,53 +1,102 @@
 import React, { useState } from 'react';
 import './Preset.css';
-import { Button, TableCell, TableRow } from '@mui/material';
+import { Alert, Button, Snackbar, TableCell, TableRow } from '@mui/material';
 import EditingPresetModal from '../../Basics/Modals/EditingPresetModal';
 import ConfirmationModal from '../../Basics/Modals/ConfirmationModal';
 
-const PresetItem = ({ preset, index }: any) => {
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+interface PresetItenProps {
+    preset: {
+        id: number,
+        name: string
+    };
+    presetType: string;
+    removeElement: Function;
+}
 
+const PresetItem = ({ preset, presetType, removeElement}: PresetItenProps) => {
+    const [presetName, setPresetName] = useState(preset.name);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState('');
+    const [successful, setSuccessful] = useState(true);
 
-  const onEdit = () => {
-    console.log("Edit");
-    setIsEditModalOpen(true);
-  };
+    const onEdit = () => {
+        setIsEditModalOpen(true);
+    };
 
-  const cancelEdit = () => {
-    setIsEditModalOpen(false);
-  };
+    const cancelEdit = () => {
+        setIsEditModalOpen(false);
+    };
 
-  const onDelete = () => {
-    console.log("Delete");
-    setIsDeleteModalOpen(true);
-  };
+    const onDelete = () => {
+        setIsDeleteModalOpen(true);
+    };
 
-  const cancelDelete = () => {
-    setIsDeleteModalOpen(false);
-  };
+    const successfulRemoval = (message: string, isSuccessful: boolean) => {
+        setOpenSnackbar(true);
+        setSnackbarMessage(message);
+        setSuccessful(isSuccessful)
+    }
+
+    const cancelDelete = () => {
+        setIsDeleteModalOpen(false);
+    };
+
+    const setNewPresetName = (value: string) => {
+        setPresetName(value);
+        setOpenSnackbar(true);
+        setSnackbarMessage("Success");
+        setSuccessful(true);
+    }
+
+    const handleCloseSnackbar = () => {
+        setOpenSnackbar(false);
+    };
+
 
   return (
-    <TableRow>
-      <TableCell>{index}</TableCell>
-      <TableCell>{preset.name}</TableCell>
-      <TableCell>
-        <Button onClick={onEdit}> Edit </Button>
-        <Button color="error" onClick={onDelete}> Delete </Button>
-        {isEditModalOpen && 
-            <EditingPresetModal
-                isOpen={true} 
-                cancelEdit={cancelEdit} 
-                presetName={preset.name}
-            />}
-        {isDeleteModalOpen && 
-            <ConfirmationModal
-                isOpen={true} 
-                cancelDelete={cancelDelete} 
-                presetName={preset.name}
-            />}
-      </TableCell>
-    </TableRow>
+        <TableRow>
+            <TableCell>{preset.id}</TableCell>
+            <TableCell>{presetName}</TableCell>
+            <TableCell>
+                <Button onClick={onEdit}> Edit </Button>
+                <Button color="error" onClick={onDelete}> Delete </Button>
+                
+                {isEditModalOpen && 
+                    <EditingPresetModal
+                        setPresetName
+                        isOpen={true} 
+                        presetType={presetType}
+                        cancelEdit={cancelEdit} 
+                        preset={preset}
+                        presetName={presetName}
+                        setNewPresetName={setNewPresetName}
+                    />
+                }
+                
+                {isDeleteModalOpen && 
+                    <ConfirmationModal
+                        removeElement={removeElement}
+                        isOpen={true} 
+                        presetType={presetType}
+                        cancelDelete={cancelDelete} 
+                        preset={preset}
+                        successfulRemoval={successfulRemoval}
+                    />
+                }
+            </TableCell>
+            <Snackbar
+                open={openSnackbar}
+                autoHideDuration={3000}
+                onClose={handleCloseSnackbar}>
+                <Alert 
+                    severity={successful ? "success" : "error"}
+                >
+                    {snackbarMessage}
+                </Alert>
+            </Snackbar>
+        </TableRow>
   );
 };
 

--- a/src/components/Admin/PresetManagement/PresetList.tsx
+++ b/src/components/Admin/PresetManagement/PresetList.tsx
@@ -2,9 +2,18 @@ import React from "react";
 import PresetItem from "./PresetItem";
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField} from "@mui/material";
 
+interface PresetListProps {
+    presets: Array<PresetItem>;
+    presetType: string;
+    removeElement: Function;
+}
 
-const PresetList = ({presets} : any) => {
-    console.log(presets);
+interface PresetItem {
+    id: number,
+    name: string
+}
+
+const PresetList = ({presets, presetType, removeElement} : PresetListProps) => {
     return (
         <TableContainer>
             {/* <TextField/> */}
@@ -20,7 +29,11 @@ const PresetList = ({presets} : any) => {
                 <TableBody>
                 {
                     presets.map((preset: any, index: number) => (
-                        <PresetItem key={preset.id}index={preset.id} preset={preset} />
+                        <PresetItem 
+                            removeElement={removeElement}
+                            key={preset.id}
+                            preset={preset} 
+                            presetType={presetType} />
                     ))
                 }
                 </TableBody>

--- a/src/components/Admin/PresetManagement/PresetList.tsx
+++ b/src/components/Admin/PresetManagement/PresetList.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import PresetItem from "./PresetItem";
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField} from "@mui/material";
+
+
+const PresetList = ({presets} : any) => {
+    console.log(presets);
+    return (
+        <TableContainer>
+            {/* <TextField/> */}
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>ID</TableCell>
+                        <TableCell>Name</TableCell>
+                        <TableCell>Options</TableCell>
+                    </TableRow>
+                </TableHead>
+
+                <TableBody>
+                {
+                    presets.map((preset: any, index: number) => (
+                        <PresetItem key={preset.id}index={preset.id} preset={preset} />
+                    ))
+                }
+                </TableBody>
+            </Table>
+        </TableContainer>
+    )
+}
+
+export default PresetList;

--- a/src/components/Admin/PresetManagement/PresetManagementPage.tsx
+++ b/src/components/Admin/PresetManagement/PresetManagementPage.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Presets from "./Presets";
+
+
+const PresetManagementPage = () => {  
+    return (
+        <div style={{width: '100%'}}>
+            <div className="admin-header">
+                <h1>Presets</h1>
+            </div>
+            <Presets/>
+        </div>
+    )
+}
+
+export default PresetManagementPage;

--- a/src/components/Admin/PresetManagement/PresetManagementPage.tsx
+++ b/src/components/Admin/PresetManagement/PresetManagementPage.tsx
@@ -15,7 +15,6 @@ const PresetManagementPage = () => {
     const fetchFormPresets = async () => {
         try {
             const response = await getFormPresets();
-            console.log(response);
             setMetrics(response.metrics);
             setCategories(response.categories);
             setIngredients(response.ingredients);
@@ -26,16 +25,43 @@ const PresetManagementPage = () => {
         }
     };
 
+    const removeElement = (presetType: string, id: number) => {
+        switch(presetType) {
+            case 'metric':
+                const updatedMetrics = metrics.filter((metric, index) => metric.id !== id);
+                setMetrics(updatedMetrics)
+                break;
+
+            case 'category':
+                const updatedCategories = categories.filter((category, index) => category.id !== id);
+                setCategories(updatedCategories)
+                break;
+
+            case 'ingredient':
+                const updatedIngredients= ingredients.filter((ingredient, index) => ingredient.id !== id);
+                setIngredients(updatedIngredients)
+                break;
+
+            case 'cuisine':
+                console.log()
+                const updatedCuisines = cuisines.filter((cuisine, index) => cuisine.id !== id);
+                setCuisines(updatedCuisines)
+                break;
+        }
+    }
+
     return (
         <div style={{ width: '100%' }}>
             <div className="admin-header">
                 <h1>Presets</h1>
             </div>
+            
             <Presets
                 metrics={metrics}
                 categories={categories}
                 ingredients={ingredients}
                 cuisines={cuisines}
+                removeElement={removeElement}
             />
         </div>
     );

--- a/src/components/Admin/PresetManagement/PresetManagementPage.tsx
+++ b/src/components/Admin/PresetManagement/PresetManagementPage.tsx
@@ -26,6 +26,7 @@ const PresetManagementPage = () => {
     };
 
     const removeElement = (presetType: string, id: number) => {
+        console.log("removing element");
         switch(presetType) {
             case 'metric':
                 const updatedMetrics = metrics.filter((metric, index) => metric.id !== id);
@@ -43,7 +44,6 @@ const PresetManagementPage = () => {
                 break;
 
             case 'cuisine':
-                console.log()
                 const updatedCuisines = cuisines.filter((cuisine, index) => cuisine.id !== id);
                 setCuisines(updatedCuisines)
                 break;
@@ -55,7 +55,7 @@ const PresetManagementPage = () => {
             <div className="admin-header">
                 <h1>Presets</h1>
             </div>
-            
+
             <Presets
                 metrics={metrics}
                 categories={categories}

--- a/src/components/Admin/PresetManagement/PresetManagementPage.tsx
+++ b/src/components/Admin/PresetManagement/PresetManagementPage.tsx
@@ -1,16 +1,44 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getFormPresets } from '../../../apis/AdminAPI/RecipeAPI.js'; // Verify the import path
 import Presets from "./Presets";
 
+const PresetManagementPage = () => {
+    const [metrics, setMetrics] = useState([]);
+    const [categories, setCategories] = useState([]);
+    const [ingredients, setIngredients] = useState([]);
+    const [cuisines, setCuisines] = useState([]);
 
-const PresetManagementPage = () => {  
+    useEffect(() => {
+        fetchFormPresets();
+    }, []);
+
+    const fetchFormPresets = async () => {
+        try {
+            const response = await getFormPresets();
+            console.log(response);
+            setMetrics(response.metrics);
+            setCategories(response.categories);
+            setIngredients(response.ingredients);
+            setCuisines(response.cuisines);
+ 
+        } catch (error) {
+             // handleApiError('fetching metrics and ingredients', error);
+        }
+    };
+
     return (
-        <div style={{width: '100%'}}>
+        <div style={{ width: '100%' }}>
             <div className="admin-header">
                 <h1>Presets</h1>
             </div>
-            <Presets/>
+            <Presets
+                metrics={metrics}
+                categories={categories}
+                ingredients={ingredients}
+                cuisines={cuisines}
+            />
         </div>
-    )
-}
+    );
+};
 
 export default PresetManagementPage;

--- a/src/components/Admin/PresetManagement/Presets.tsx
+++ b/src/components/Admin/PresetManagement/Presets.tsx
@@ -1,0 +1,72 @@
+import { Box, Tabs, Tab, CustomTabPanel, Typography } from "@mui/material";
+import React from "react";
+
+interface TabPanelProps {
+    children?: React.ReactNode;
+    index: number;
+    value: number;
+}
+
+const Presets = () => {
+    const [value, setValue] = React.useState(0);
+
+    const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+        setValue(newValue);
+    };
+
+    function CustomTabPanel(props: TabPanelProps) {
+        const { children, value, index, ...other } = props;
+      
+        return (
+            <div
+                role="tabpanel"
+                hidden={value !== index}
+                id={`simple-tabpanel-${index}`}
+                aria-labelledby={`simple-tab-${index}`}
+                {...other}
+            >
+                {value === index && (
+                <Box sx={{ p: 3 }}>
+                    <Typography>{children}</Typography>
+                </Box>
+                )}
+            </div>
+        );
+    }
+
+
+    function a11yProps(index: number) {
+        return {
+            id: `simple-tab-${index}`,
+            'aria-controls': `simple-tabpanel-${index}`,
+        };
+    }
+  
+      
+    return (
+        <div>
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+                    <Tab label="Metrics" {...a11yProps(0)} />
+                    <Tab label="Ingredients" {...a11yProps(1)} />
+                    <Tab label="Categories" {...a11yProps(2)} />
+                    <Tab label="Cusines" {...a11yProps(3)} />
+                </Tabs>
+                </Box>
+                <CustomTabPanel value={value} index={0}>
+                    Metrics
+                </CustomTabPanel>
+                <CustomTabPanel value={value} index={1}>
+                    Ingredients
+                </CustomTabPanel>
+                <CustomTabPanel value={value} index={2}>
+                    Categories
+                </CustomTabPanel>
+                <CustomTabPanel value={value} index={3}>
+                    Cusines
+                </CustomTabPanel>
+        </div>
+    )
+}
+
+export default Presets;

--- a/src/components/Admin/PresetManagement/Presets.tsx
+++ b/src/components/Admin/PresetManagement/Presets.tsx
@@ -1,5 +1,6 @@
-import { Box, Tabs, Tab, CustomTabPanel, Typography } from "@mui/material";
+import { Box, Tabs, Tab } from "@mui/material";
 import React from "react";
+import PresetList from "./PresetList";
 
 interface TabPanelProps {
     children?: React.ReactNode;
@@ -7,7 +8,7 @@ interface TabPanelProps {
     value: number;
 }
 
-const Presets = () => {
+const Presets = ({metrics, categories, ingredients, cuisines } : any) => {
     const [value, setValue] = React.useState(0);
 
     const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -27,7 +28,7 @@ const Presets = () => {
             >
                 {value === index && (
                 <Box sx={{ p: 3 }}>
-                    <Typography>{children}</Typography>
+                    {children}
                 </Box>
                 )}
             </div>
@@ -42,9 +43,8 @@ const Presets = () => {
         };
     }
   
-      
     return (
-        <div>
+        <div style={{width: '75%', maxWidth: "750px"}}>
             <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
                 <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
                     <Tab label="Metrics" {...a11yProps(0)} />
@@ -52,19 +52,19 @@ const Presets = () => {
                     <Tab label="Categories" {...a11yProps(2)} />
                     <Tab label="Cusines" {...a11yProps(3)} />
                 </Tabs>
-                </Box>
-                <CustomTabPanel value={value} index={0}>
-                    Metrics
-                </CustomTabPanel>
-                <CustomTabPanel value={value} index={1}>
-                    Ingredients
-                </CustomTabPanel>
-                <CustomTabPanel value={value} index={2}>
-                    Categories
-                </CustomTabPanel>
-                <CustomTabPanel value={value} index={3}>
-                    Cusines
-                </CustomTabPanel>
+            </Box>
+            <CustomTabPanel value={value} index={0}>
+                <PresetList presets={metrics}/>
+            </CustomTabPanel>
+            <CustomTabPanel value={value} index={1}>
+                <PresetList presets={ingredients}/>
+            </CustomTabPanel>
+            <CustomTabPanel value={value} index={2}>
+                <PresetList presets={categories}/>
+            </CustomTabPanel>
+            <CustomTabPanel value={value} index={3}>
+                <PresetList presets={cuisines}/>
+            </CustomTabPanel>
         </div>
     )
 }

--- a/src/components/Admin/PresetManagement/Presets.tsx
+++ b/src/components/Admin/PresetManagement/Presets.tsx
@@ -8,7 +8,20 @@ interface TabPanelProps {
     value: number;
 }
 
-const Presets = ({metrics, categories, ingredients, cuisines } : any) => {
+interface PresetProps {
+    metrics: Array<PresetItem>;
+    categories: Array<PresetItem>;
+    ingredients: Array<PresetItem>;
+    cuisines: Array<PresetItem>;
+    removeElement: Function;
+}
+
+interface PresetItem {
+    id: number,
+    name: string
+}
+
+const Presets = ({metrics, categories, ingredients, cuisines, removeElement } : PresetProps) => {
     const [value, setValue] = React.useState(0);
 
     const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -54,16 +67,16 @@ const Presets = ({metrics, categories, ingredients, cuisines } : any) => {
                 </Tabs>
             </Box>
             <CustomTabPanel value={value} index={0}>
-                <PresetList presets={metrics}/>
+                <PresetList presets={metrics} presetType={"metric"} removeElement={removeElement}/>
             </CustomTabPanel>
             <CustomTabPanel value={value} index={1}>
-                <PresetList presets={ingredients}/>
+                <PresetList presets={ingredients} presetType={"ingredient"} removeElement={removeElement}/>
             </CustomTabPanel>
             <CustomTabPanel value={value} index={2}>
-                <PresetList presets={categories}/>
+                <PresetList presets={categories} presetType={"category"} removeElement={removeElement}/>
             </CustomTabPanel>
             <CustomTabPanel value={value} index={3}>
-                <PresetList presets={cuisines}/>
+                <PresetList presets={cuisines} presetType={"cuisine"} removeElement={removeElement}/>
             </CustomTabPanel>
         </div>
     )

--- a/src/components/Admin/RecipeForm/RecipeForm.css
+++ b/src/components/Admin/RecipeForm/RecipeForm.css
@@ -2,6 +2,7 @@
     width: 75%;
     padding: 50px;
     background-color: #fff9eb;
+    margin: auto;
 }
 
 .recipe-form-container {

--- a/src/components/Admin/RecipeForm/RecipeForm.tsx
+++ b/src/components/Admin/RecipeForm/RecipeForm.tsx
@@ -135,7 +135,11 @@ const RecipeForm = () => {
             ) : (
                 <div className="recipe-form-container">
                     <h1>Recipe Form</h1>
-                    <MetadataForm categoryPresets={formPresets.categories} cuisinePresets={formPresets.cuisines} metadata={recipeMetadata}/>
+                    <MetadataForm 
+                        categoryPresets={formPresets.categories.map((category, index) => category.name)} 
+                        cuisinePresets={formPresets.cuisines.map((cuisine, index) => cuisine.name)}
+                        metadata={recipeMetadata}
+                    />
                     <SummaryForm recipeSummary={recipeSummary}/>
                     <IngredientForm 
                         metricPresets={formPresets.metrics}

--- a/src/components/Admin/RecipesPage/RecipeDataRow.tsx
+++ b/src/components/Admin/RecipesPage/RecipeDataRow.tsx
@@ -3,7 +3,7 @@ import Button from '@mui/material/Button';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { updateRecipeStatus } from '../../../apis/AdminAPI/RecipeAPI.js'
-import { TableCell, TableRow } from '@mui/material';
+import { Checkbox, TableCell, TableRow } from '@mui/material';
 
 interface RecipeObjectProp {
     id: number;
@@ -37,7 +37,7 @@ const RecipeCard = ({recipe}: RecipeCardProps) => {
         <TableRow
             key={recipe.title}
             sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
-
+            {/* <TableCell><Checkbox/></TableCell> */}
             <TableCell>{recipe.id}</TableCell>
             <TableCell component="th" scope="row">
                 <img style={{width: 100, height: 100, objectFit: "cover"}} src={recipe.image}/>

--- a/src/components/Admin/RecipesPage/Recipes.tsx
+++ b/src/components/Admin/RecipesPage/Recipes.tsx
@@ -6,10 +6,13 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { getAllRecipesInAdmin } from "../../../apis/AdminAPI/RecipeAPI.js";
+import { Checkbox } from "@mui/material";
 
 interface RecipesPageProps {
     recipes: Array<Object>
 }
+
+
 
 const Recipes = ({recipes}: RecipesPageProps) => {
     return (
@@ -17,6 +20,7 @@ const Recipes = ({recipes}: RecipesPageProps) => {
             <Table aria-label="simple table">
                 <TableHead>
                     <TableRow>
+                        {/* <TableCell align="left"><Checkbox/></TableCell> */}
                         <TableCell align="left"><b>ID</b></TableCell>
                         <TableCell/>
                         <TableCell><b>Recipe</b></TableCell>

--- a/src/components/Admin/RecipesPage/RecipesPage.tsx
+++ b/src/components/Admin/RecipesPage/RecipesPage.tsx
@@ -57,11 +57,10 @@ const RecipesPage = ({}) => {
             </div>
 
             <div className="filters-and-search-container">
-                <div className="search-container">
-                    <TextField placeholder="Search Recipes" fullWidth/>
+                {/* <div className="search-container">
+                    <TextField placeholder="Search Recipe Titles" fullWidth/>
                 </div>
                 <div className="filters-container">   
-                    <Button variant="contained" fullWidth>Select All</Button>   
                     <FormControl fullWidth>
                         <InputLabel id="demo-simple-select-label">Status</InputLabel>
                         <Select
@@ -85,12 +84,14 @@ const RecipesPage = ({}) => {
                             <MenuItem value={"Archived"}>Archived</MenuItem>
                         </Select>
                     </FormControl>
-                    <Button>Sort</Button>
-                </div>
+                    <Button>Sort</Button> */}
+                {/* </div> */}
             </div>
-            <div className="applied-filters-container">
+            {/* <div className="applied-filters-container">
                 <Button>Clear Filter</Button>
-            </div>
+            </div> */}
+
+            {/* <Button variant="contained" fullWidth>Select All</Button>    */}
             
             <Recipes recipes={recipes} />
 

--- a/src/components/Basics/Modals/ConfirmationModal.tsx
+++ b/src/components/Basics/Modals/ConfirmationModal.tsx
@@ -6,8 +6,9 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import {deletePreset} from '../../../apis/AdminAPI/PresetAPI.js';
 
-const ConfirmationModal = ({isOpen, cancelDelete, presetName}: any) => {
+const ConfirmationModal = ({isOpen, cancelDelete, preset, presetType, removeElement, successfulRemoval}: any) => {
     const [open, setOpen] = useState(isOpen);
     
     const handleClose = () => {
@@ -15,14 +16,32 @@ const ConfirmationModal = ({isOpen, cancelDelete, presetName}: any) => {
         cancelDelete(false);
     };
 
+    const deleteAndRemovePreset = async () => {
+        const response = await deletePreset(presetType, preset.id);
+        console.dir(response);
+        if (response.message == "Sucess") {
+            removeElement(presetType, preset.id);
+            successfulRemoval("Successfully Removed Element", true);
+        }
+        else {
+            successfulRemoval(response.message, false);
+        }
+        setOpen(false);
+    }
+
     return (
         <Dialog open={open} onClose={handleClose}>
-            <DialogTitle>Are you sure you want to delete this preset?</DialogTitle>
+            <DialogTitle>Confirmation</DialogTitle>
             <DialogContent>
-                <b>{presetName}</b>
+                <DialogContentText>
+                    Permanently delete Preset? This will effect all recipes that use this item.
+                    <br/>
+                    <br/>
+                    <b>{preset.name}</b>
+                </DialogContentText>
             </DialogContent>
             <DialogActions>
-                <Button color="error"onClick={handleClose}>Delete</Button>
+                <Button color="error"onClick={deleteAndRemovePreset}>Delete</Button>
                 <Button onClick={handleClose}>Cancel</Button>
             </DialogActions>
         </Dialog>

--- a/src/components/Basics/Modals/ConfirmationModal.tsx
+++ b/src/components/Basics/Modals/ConfirmationModal.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+const ConfirmationModal = ({isOpen, cancelDelete, presetName}: any) => {
+    const [open, setOpen] = useState(isOpen);
+    
+    const handleClose = () => {
+        setOpen(false);
+        cancelDelete(false);
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose}>
+            <DialogTitle>Are you sure you want to delete this preset?</DialogTitle>
+            <DialogContent>
+                <b>{presetName}</b>
+            </DialogContent>
+            <DialogActions>
+                <Button color="error"onClick={handleClose}>Delete</Button>
+                <Button onClick={handleClose}>Cancel</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default ConfirmationModal;

--- a/src/components/Basics/Modals/ConfirmationModal.tsx
+++ b/src/components/Basics/Modals/ConfirmationModal.tsx
@@ -18,8 +18,8 @@ const ConfirmationModal = ({isOpen, cancelDelete, preset, presetType, removeElem
 
     const deleteAndRemovePreset = async () => {
         const response = await deletePreset(presetType, preset.id);
-        console.dir(response);
-        if (response.message == "Sucess") {
+        
+        if (response.message == "Sucess" || response) {
             removeElement(presetType, preset.id);
             successfulRemoval("Successfully Removed Element", true);
         }
@@ -34,10 +34,12 @@ const ConfirmationModal = ({isOpen, cancelDelete, preset, presetType, removeElem
             <DialogTitle>Confirmation</DialogTitle>
             <DialogContent>
                 <DialogContentText>
-                    Permanently delete Preset? This will effect all recipes that use this item.
+                    Permanently delete Preset? 
                     <br/>
                     <br/>
                     <b>{preset.name}</b>
+
+                    <p style={{color: "red"}}>This will affect all recipes that use this item, including published recipes.</p>
                 </DialogContentText>
             </DialogContent>
             <DialogActions>

--- a/src/components/Basics/Modals/EditingPresetModal.tsx
+++ b/src/components/Basics/Modals/EditingPresetModal.tsx
@@ -6,23 +6,60 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import {editPreset} from '../../../apis/AdminAPI/PresetAPI.js';
+import { Alert, Snackbar } from "@mui/material";
 
-const EditingPresetModal = ({isOpen, cancelEdit, presetName}: any) => {
+const EditingPresetModal = ({isOpen, cancelEdit, preset, presetType, presetName, setNewPresetName}: any) => {
     const [open, setOpen] = useState(isOpen);
-    
+    const [rename, setRename] = useState(presetName);
+    const [hasInputError, setHasInputError] = useState(false);
+
     const handleClose = () => {
         setOpen(false);
         cancelEdit(false);
     };
 
+    const renameRoom = async () => {
+        if (rename) {
+            try {
+                const result = await editPreset(presetType, preset.id, rename);
+            
+                if (result) {
+                    console.log(result.name);
+                    setNewPresetName(result.name);
+                    handleClose();
+                }
+            } catch (error) {
+              // Handle errors from the API call
+              console.error("Error editing preset:", error);
+              // You might want to set an error state or show an error message to the user
+            }
+        } else {
+            setHasInputError(true);
+        }
+    }
+
+    const setNewName = (event: any) => {
+        const newValue = event.target.value;
+        if (newValue) {
+            setHasInputError(false)
+        }
+        setRename(newValue);
+    }
+
     return (
         <Dialog open={open} onClose={handleClose}>
             <DialogTitle>Editing Preset</DialogTitle>
             <DialogContent>
-                <TextField sx={{width: 350}} value={presetName}/>
+                <TextField 
+                    sx={{width: 350}}
+                    value={rename}
+                    onChange={setNewName} 
+                    error={hasInputError}
+                />
             </DialogContent>
             <DialogActions>
-                <Button onClick={handleClose}>Submit</Button>
+                <Button onClick={renameRoom}>Submit</Button>
                 <Button color="error" onClick={handleClose}>Cancel</Button>
             </DialogActions>
         </Dialog>

--- a/src/components/Basics/Modals/EditingPresetModal.tsx
+++ b/src/components/Basics/Modals/EditingPresetModal.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+const EditingPresetModal = ({isOpen, cancelEdit, presetName}: any) => {
+    const [open, setOpen] = useState(isOpen);
+    
+    const handleClose = () => {
+        setOpen(false);
+        cancelEdit(false);
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose}>
+            <DialogTitle>Editing Preset</DialogTitle>
+            <DialogContent>
+                <TextField sx={{width: 350}} value={presetName}/>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose}>Submit</Button>
+                <Button color="error" onClick={handleClose}>Cancel</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default EditingPresetModal;

--- a/src/components/Recipe/RecipeNotes/RecipeNotes.tsx
+++ b/src/components/Recipe/RecipeNotes/RecipeNotes.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import "./Notes.css"
-const RecipeNotes = ({notes}) => {
+
+interface NotesProps { 
+    notes: Array<NoteProps>
+}
+
+interface NoteProps {
+    stepId: number;
+    description: string;
+}
+
+const RecipeNotes = ({notes}: NotesProps) => {
     return (
         <div className="notes-container">
             { notes.length > 0 && 

--- a/src/components/Recipe/RecipeNotes/RecipeNotes.tsx
+++ b/src/components/Recipe/RecipeNotes/RecipeNotes.tsx
@@ -3,10 +3,11 @@ import "./Notes.css"
 const RecipeNotes = ({notes}) => {
     return (
         <div className="notes-container">
-            <div className="RecipeDetailPage-ingr-label RecipeDetailPage-body-label">
-                Notes
-            </div>
-            
+            { notes.length > 0 && 
+                 <div className="RecipeDetailPage-ingr-label RecipeDetailPage-body-label">
+                    Notes
+                </div>
+            }
             {
                 notes.map((note: any, index: number) => (
                     <div className="RecipeDetailPage-ingr">
@@ -17,6 +18,7 @@ const RecipeNotes = ({notes}) => {
                     </div>
                 ))
             }
+           
         </div>
     )
 }

--- a/src/components/Recipes/Recipes.css
+++ b/src/components/Recipes/Recipes.css
@@ -1,0 +1,10 @@
+.recipe-container {
+    margin: auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    max-width: 1250px;
+    height: 100%;
+    width: 100%;
+}
+

--- a/src/components/Recipes/Recipes.tsx
+++ b/src/components/Recipes/Recipes.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import RecipeBox from './RecipeBox/RecipeBox.js';
+import './Recipes.css';
 
 interface RecipesProps {
     recipes: Array<Object>,
@@ -8,7 +9,7 @@ interface RecipesProps {
 
 const Recipes = ({recipes, togglePage}: RecipesProps) => {
     return (
-        <div style={{display: "flex", flexWrap: "wrap", justifyContent:"space-evenly"}}>
+        <div className="recipe-container">
             {
                 recipes.map((recipe: any) => (
                     <RecipeBox key={recipe.id} togglePage={togglePage} recipe={recipe}/>


### PR DESCRIPTION
# Overview

Revamped the admin page to be able to edit and delete presets for recipes. The newly changed admin page has tabs now for both presets and recipes.

<img width="1505" alt="image" src="https://github.com/nichc74/cook-with-me/assets/19677542/780a334d-dc0f-4b98-8d1b-5bd8d2277bc8">

<img width="1076" alt="image" src="https://github.com/nichc74/cook-with-me/assets/19677542/ad880b54-fcd7-4e54-9cb6-489bb7836274">
